### PR TITLE
add pthread libs to gmock target

### DIFF
--- a/vendor/googlemock-1.7.0/CMakeLists.txt
+++ b/vendor/googlemock-1.7.0/CMakeLists.txt
@@ -1,8 +1,11 @@
 project(gmock CXX C)
 cmake_minimum_required(VERSION 2.6.2)
 
+find_package(Threads)
+
 include_directories(include)
 
 add_library(gmock src/gmock-gtest-all.cc)
+target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
 
 add_library(gmock_main src/gmock-gtest-all.cc src/gmock_main.cc)


### PR DESCRIPTION
Downstream packages shouldn't need to care about this detail.