### PR TITLE
Force static linking instead of honoring BUILD_SHARED_LIBS

### DIFF
--- a/vendor/googlemock-1.7.0/CMakeLists.txt
+++ b/vendor/googlemock-1.7.0/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Threads)
 
 include_directories(include)
 
-add_library(gmock src/gmock-gtest-all.cc)
+add_library(gmock STATIC src/gmock-gtest-all.cc)
 target_link_libraries(gmock ${CMAKE_THREAD_LIBS_INIT})
 
-add_library(gmock_main src/gmock-gtest-all.cc src/gmock_main.cc)
+add_library(gmock_main STATIC src/gmock-gtest-all.cc src/gmock_main.cc)


### PR DESCRIPTION
Force static linking instead of honoring BUILD_SHARED_LIBS

See https://github.com/ros2/rmw/pull/81#issuecomment-291997813

Connects to ros2/ros2#306